### PR TITLE
Add requires_arc flag to podspec

### DIFF
--- a/DHAppleReceiptParser.podspec
+++ b/DHAppleReceiptParser.podspec
@@ -17,6 +17,7 @@ https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreRec
   s.license      = "MIT"
   s.author       = { "Chase Caster" => "chasec@darkhorse.com" }
   s.platform     = :ios, "7.0"
+  s.requires_arc = true
   s.source       = { :git => "https://github.com/DarkHorseComics/DHAppleReceiptParser.git", :tag => "1.0.0" }
   s.source_files  = "*.{h,m}", "asn1_parser/*{h,c}"
   s.public_header_files = "DHAppStoreReceipt.h"


### PR DESCRIPTION
Hey

It looks like CocoaPods doesn't enable ARC by default [[1](http://www.customs.govt.nz/features/charges/feetypes/Pages/default.aspx)]. This pull request just adds the requires_arc flag to the podspec file.

Really nice project by the way.
Thanks, Craz
